### PR TITLE
PERF: Optimize StringExtensions.cs

### DIFF
--- a/src/NetDevPack/Utilities/StringExtensions.cs
+++ b/src/NetDevPack/Utilities/StringExtensions.cs
@@ -288,8 +288,7 @@ namespace NetDevPack.Utilities
 
                 onlyNumbers[lastIndex++] = c;
             }
-            Array.Resize(ref onlyNumbers, lastIndex);
-            return new string(onlyNumbers);
+            return new string(onlyNumbers, 0, lastIndex);
         }
 
 


### PR DESCRIPTION
Hi, I've tried to make some performance optimizations to this repo. Following are the benchmark results before and after the changes:

**Benchmarks before changes:**
|               Method |     Mean |   Error |  StdDev |  Gen 0 | Allocated |
|--------------------- |---------:|--------:|--------:|-------:|----------:|
|          OnlyNumbers | 161.3 ns | 2.40 ns | 2.13 ns | 0.0072 |     136 B |
| NetDevPackOnlyNumber | 149.5 ns | 3.09 ns | 2.89 ns | 0.0103 |     192 B |

**Benchmarks after changes:**
|               Method |     Mean |   Error |  StdDev |  Gen 0 | Allocated |
|--------------------- |---------:|--------:|--------:|-------:|----------:|
|          OnlyNumbers | 165.4 ns | 3.31 ns | 4.54 ns | 0.0072 |     136 B |
| NetDevPackOnlyNumber | 126.9 ns | 2.68 ns | 4.61 ns | 0.0076 |     144 B |

As you can see the durations and allocations have gone down. I've also made sure that all the unit tests pass following these changes as well. Could you please confirm whether or not you think my changes are valid?

Thank you!
