### PR TITLE
padronizando "actions/setup-dotnet"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,34 +16,19 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-        
+
       - name: Setup .NET 7
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 7.0.x        
-
-      - name: Setup .NET 6
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 6.0.x        
-
-      - name: Setup .NET 5
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 5.0.x
-
-      - name: Setup .NET Core 3.1
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 3.1.x
-          
-      - name: Setup .NET Core 2.1
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 2.1.x
+          dotnet-version: |
+            7.0.x
+            6.0.x
+            5.0.x
+            3.1.x
+            3.0.x
 
       - name: Restore dependencies
-        run: dotnet restore 
+        run: dotnet restore
 
       - name: Build
         run: dotnet build --no-restore

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Setup .NET 7
+      - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
             7.0.x

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Setup .NET 7
+      - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
             7.0.x

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,28 +15,13 @@ jobs:
       - name: Setup .NET 7
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 7.0.x
-        
-      - name: Setup .NET 6
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 6.0.x
+          dotnet-version: |
+            7.0.x
+            6.0.x
+            5.0.x
+            3.1.x
+            3.0.x
 
-      - name: Setup .NET 5
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 5.0.x
-
-      - name: Setup .NET Core 3.1
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 3.1.x
-
-      - name: Setup .NET Core 2.1
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 2.1.x
-          
       - name: Restore dependencies
         run: dotnet restore
 


### PR DESCRIPTION
pelo que vi [aqui](https://github.com/NetDevPack/NetDevPack/blob/master/src/NetDevPack/NetDevPack.csproj#L4) e [aqui](https://github.com/NetDevPack/NetDevPack/blob/master/src/NetDevPack.Perf/NetDevPack.Perf.csproj#L5), o projeto utiliza `netstandard2.1`, e pelo vi na [documentação do netstandard2.1](https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-1), as versões suportadas são apenas `3.0`, `3.1`, `5.0`, `6.0` e `7.0`
![image](https://user-images.githubusercontent.com/15821724/208454638-c841a271-b459-42bc-bba9-787f6596fd8b.png)

além disso, pelo que vi na [doc do setup-dotnet](https://github.com/actions/setup-dotnet#usage), é possivel utilizar múltiplas versões dessa forma
![image](https://user-images.githubusercontent.com/15821724/208454564-58e3f83a-f20c-4e64-a1a5-35d7d37b488f.png)